### PR TITLE
fix: set imagePullSecrets for ECR in production deployment

### DIFF
--- a/.deploy/values.yaml
+++ b/.deploy/values.yaml
@@ -10,7 +10,8 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
-imagePullSecrets: []
+imagePullSecrets:
+  - name: aws-ecr-auth
 nameOverride: ""
 fullnameOverride: ""
 

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -50,7 +50,6 @@ jobs:
       helm-set-values: |
         aws.bucketName=${{ vars.AWS_S3_BUCKET }}
         aws.region=${{ vars.AWS_REGION }}
-        imagePullSecrets[0].name=aws-ecr-auth
       cluster-name: ${{ vars.K8S_CLUSTER_NAME_SD_PROD }}
       environment-name: production
       environment-url: ${{ vars.ENVIRONMENT_URL_PROD }}

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -50,6 +50,7 @@ jobs:
       helm-set-values: |
         aws.bucketName=${{ vars.AWS_S3_BUCKET }}
         aws.region=${{ vars.AWS_REGION }}
+        imagePullSecrets[0].name=aws-ecr-auth
       cluster-name: ${{ vars.K8S_CLUSTER_NAME_SD_PROD }}
       environment-name: production
       environment-url: ${{ vars.ENVIRONMENT_URL_PROD }}


### PR DESCRIPTION
## Problem

When a pod is rescheduled to a node without a cached image, it fails with `ImagePullBackOff` because there are no `imagePullSecrets` configured on the pod spec.

## Fix

Set aws-ecr-auth as default imagePullSecrets in .deploy/values.yaml, aligning with the same pattern used in other apps.